### PR TITLE
DevC:Pune Link Fix

### DIFF
--- a/DevCGlobalDirectory.md
+++ b/DevCGlobalDirectory.md
@@ -78,7 +78,7 @@
   - Leads:
     - Sangeeta Gupta
     - Navneet Singh
-  - Facebook Group: https://www.facebook.com/groups/DevCIndore/
+  - Facebook Group: https://www.facebook.com/groups/DevCPune/
   - Region: India
   - Github: https://github.com/devcpune
 


### PR DESCRIPTION
In the DevCGlobalDirectory.md file Pune circle had the DevC:Indore FB Group Link.
So kind of changed the URL and fixed it!